### PR TITLE
fix: migrator error of gorm on second run

### DIFF
--- a/infrastructure/database/postgres.go
+++ b/infrastructure/database/postgres.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"database/sql"
 	_ "github.com/lib/pq"
 	"github.com/tiagorlampert/CHAOS/internal/environment"
 	"gorm.io/driver/postgres"
@@ -12,28 +11,13 @@ import (
 const driverName = "postgres"
 
 func NewPostgresClient(configuration environment.Postgres) (*Provider, error) {
-	db, err := newConnection(configuration.BuildConnectionString())
-	if err != nil {
-		return nil, err
-	}
+	connString := configuration.BuildConnectionString()
 	gormConfig := &gorm.Config{NamingStrategy: schema.NamingStrategy{TablePrefix: tablePrefix}}
-	gormDB, err := gorm.Open(postgres.New(postgres.Config{Conn: db}), gormConfig)
+	gormDB, err := gorm.Open(postgres.New(postgres.Config{DSN: connString}), gormConfig)
 	if err != nil {
 		return nil, err
 	}
 	return &Provider{
 		Conn: gormDB,
 	}, nil
-}
-
-func newConnection(connString string) (*sql.DB, error) {
-	db, err := sql.Open(driverName, connString)
-	if err != nil {
-		return nil, err
-	}
-	err = db.Ping()
-	if err != nil {
-		return nil, err
-	}
-	return db, nil
 }


### PR DESCRIPTION
See go-gorm/gorm#5409.

The solution is referenced from <https://github.com/go-gorm/gorm/issues/5409#issuecomment-1151949457>

```go
db, err := gorm.Open(postgres.New(postgres.Config{
  DSN: "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai", // data source name, refer https://github.com/jackc/pgx
  PreferSimpleProtocol: true, // disables implicit prepared statement usage. By default pgx automatically uses the extended protocol
}), &gorm.Config{})
```

Have a nice day. :-)