### PR TITLE
Fix compile error

### DIFF
--- a/services/client/client_service.go
+++ b/services/client/client_service.go
@@ -176,7 +176,7 @@ func (c clientService) BuildClient(input BuildClientBinaryInput) (string, error)
 	switch system.DetectOS() {
 	case system.Windows:
 		cmd = exec.Command("cmd")
-		cmd.SysProcAttr = syscallCmd.GetCmdSyscall(buildCmd)
+		cmd.SysProcAttr = syscallCmd.GetSyscallCmdLine(buildCmd)
 		break
 	default:
 		cmd = exec.Command("sh", "-c", buildCmd)


### PR DESCRIPTION
Fix compile error
# github.com/tiagorlampert/CHAOS/services/client
services\client\client_service.go:179:32: undefined: syscallCmd.GetCmdSyscall