### PR TITLE
Add lab/ scaffolding for resource-light local testing

### DIFF
--- a/lab/chaos-client.wsb
+++ b/lab/chaos-client.wsb
@@ -1,0 +1,20 @@
+<Configuration>
+  <VGpu>Disable</VGpu>
+  <Networking>Default</Networking>
+  <MemoryInMB>2048</MemoryInMB>
+  <AudioInput>Disable</AudioInput>
+  <VideoInput>Disable</VideoInput>
+  <ProtectedClient>Enable</ProtectedClient>
+  <ClipboardRedirection>Disable</ClipboardRedirection>
+  <PrinterRedirection>Disable</PrinterRedirection>
+  <MappedFolders>
+    <MappedFolder>
+      <HostFolder>C:\chaos-lab\client</HostFolder>
+      <SandboxFolder>C:\Users\WDAGUtilityAccount\Desktop\client</SandboxFolder>
+      <ReadOnly>true</ReadOnly>
+    </MappedFolder>
+  </MappedFolders>
+  <LogonCommand>
+    <Command>explorer.exe C:\Users\WDAGUtilityAccount\Desktop\client</Command>
+  </LogonCommand>
+</Configuration>

--- a/lab/docker-compose.yml
+++ b/lab/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  chaos:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    image: chaos:lab
+    container_name: chaos-lab
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    environment:
+      PORT: "8080"
+      SQLITE_DATABASE: "chaos"
+      GIN_MODE: "release"
+    volumes:
+      - ./data/database:/database
+      - ./data/temp:/temp


### PR DESCRIPTION
## Summary

Adds a small `lab/` directory with two helper files that make it easier
to test CHAOS locally without spinning up a full VM. Nothing in the main
project is touched.

- **`lab/docker-compose.yml`** — builds the existing `Dockerfile`, runs
  the server in SQLite mode on port 8080, and persists `database/` and
  `temp/` under `lab/data/` (already covered by the project `.gitignore`).
  One-command server: `cd lab && docker compose up -d --build`.

- **`lab/chaos-client.wsb`** — a Windows Sandbox config for testing the
  Windows client. 2 GB RAM, GPU/audio/video/clipboard/printer disabled,
  `ProtectedClient` on. A read-only mapped folder
  (`C:\chaos-lab\client` → Desktop) lets you drop the built client
  binary into a disposable sandbox; closing the window discards
  everything, so each run starts clean.

## Why

Right now contributors have to set up a VM by hand to test client
behaviour safely. This makes the smallest reasonable lab setup a
two-file checkin so it's reproducible and version-controlled.

## Notes for reviewers

- No source code or build changes — purely additive scaffolding under `lab/`.
- The `.wsb` requires Windows 10/11 Pro/Enterprise with the Windows
  Sandbox optional feature enabled (`Optionalfeatures.exe`).
- Compose volumes resolve to `lab/data/database` and `lab/data/temp`,
  which match the existing `.gitignore` rules (`database/`, `temp/`).

## Test plan

- [ ] `cd lab && docker compose up -d --build` brings the server up on http://localhost:8080
- [ ] Default login `admin/admin` works
- [ ] `docker compose down` stops cleanly; data persists in `lab/data/`
- [ ] Double-clicking `chaos-client.wsb` on a Windows host opens a sandbox with the mapped client folder on the desktop
- [ ] Sandbox can reach the host's compose server on port 8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)